### PR TITLE
trezor: show chunkified address

### DIFF
--- a/src/main/java/com/sparrowwallet/lark/trezor/TrezorDevice.java
+++ b/src/main/java/com/sparrowwallet/lark/trezor/TrezorDevice.java
@@ -178,7 +178,8 @@ public class TrezorDevice implements Closeable {
                 .addAllAddressN(KeyDerivation.parsePath(path).stream().map(ChildNumber::i).toList())
                 .setCoinName(getCoinName(network))
                 .setShowDisplay(showDisplay)
-                .setIgnoreXpubMagic(ignoreXpubMagic);
+                .setIgnoreXpubMagic(ignoreXpubMagic)
+                .setChunkify(true);
         if(multisig != null) {
             getAddress.setMultisig(multisig);
         }


### PR DESCRIPTION
It should help address verification:
<img width=300 src="https://github.com/user-attachments/assets/abb61d06-ae9c-4574-a750-1dc08a1d8f9f">
Added in https://github.com/trezor/trezor-firmware/pull/3237.