### PR TITLE
fix: KeepKey passphrase support

### DIFF
--- a/src/main/java/com/sparrowwallet/lark/TrezorClient.java
+++ b/src/main/java/com/sparrowwallet/lark/TrezorClient.java
@@ -56,7 +56,6 @@ public class TrezorClient extends HardwareClient {
     private final ByteBuffer portNumbers = ByteBuffer.allocateDirect(7);
     private String passphrase = "";
     private TrezorNoiseConfig noiseConfig;
-    private byte[] sessionId;
 
     private WalletModel model;
     private TrezorModel trezorModel;
@@ -84,12 +83,12 @@ public class TrezorClient extends HardwareClient {
     private void prepareDevice(TrezorDevice trezorDevice) throws DeviceException {
         trezorDevice.refreshFeatures();
         if(trezorDevice.getModel() == TrezorModel.T1B1 || trezorDevice.getModel() == TrezorModel.KEEPKEY || trezorDevice.getModel() == TrezorModel.ONEKEY_CLASSIC_1S) {
-            trezorDevice.initDevice(this.sessionId);
+            trezorDevice.initDevice();
         } else {
             try {
                 trezorDevice.ensureUnlocked();
             } catch(DeviceException e) {
-                trezorDevice.initDevice(this.sessionId);
+                trezorDevice.initDevice();
             }
         }
 
@@ -111,10 +110,7 @@ public class TrezorClient extends HardwareClient {
         }
         if(trezorDevice.getFeatures().getInitialized()) {
             initializeMasterFingerprint(trezorDevice);
-            this.sessionId = trezorDevice.getSessionId();
-            if(passphrase != null && !passphrase.isEmpty()) {
-                this.needsPassphraseSent = false; //Passphrase was provided by the user, so it's already sent
-            }
+            this.needsPassphraseSent = false; //Passphrase is always needed for the above to have worked, so it's already sent
         } else {
             throw new DeviceNotReadyException(getHardwareType().getDisplayName() + " is not initialized.");
         }

--- a/src/main/java/com/sparrowwallet/lark/trezor/TrezorDevice.java
+++ b/src/main/java/com/sparrowwallet/lark/trezor/TrezorDevice.java
@@ -78,15 +78,8 @@ public class TrezorDevice implements Closeable, ProtocolCallbacks {
     }
 
     public void initDevice() throws DeviceException {
-        initDevice(null);
-    }
-
-    public void initDevice(byte[] previousSessionId) throws DeviceException {
-        TrezorMessageManagement.Initialize.Builder builder = TrezorMessageManagement.Initialize.newBuilder();
-        if(previousSessionId != null && previousSessionId.length > 0) {
-            builder.setSessionId(ByteString.copyFrom(previousSessionId));
-        }
-        Message response = protocol.callRaw(builder.build());
+        TrezorMessageManagement.Initialize initialize = TrezorMessageManagement.Initialize.newBuilder().build();
+        Message response = protocol.callRaw(initialize);
         if(response instanceof TrezorMessageManagement.Features msgFeatures) {
             this.sessionId = msgFeatures.getSessionId().toByteArray();
             refreshFeatures(msgFeatures);
@@ -411,10 +404,6 @@ public class TrezorDevice implements Closeable, ProtocolCallbacks {
         }
 
         return features.getCapabilitiesList().contains(TrezorMessageManagement.Features.Capability.Capability_PassphraseEntry);
-    }
-
-    public byte[] getSessionId() {
-        return sessionId;
     }
 
     @Override

--- a/src/main/java/com/sparrowwallet/lark/trezor/TrezorDevice.java
+++ b/src/main/java/com/sparrowwallet/lark/trezor/TrezorDevice.java
@@ -78,8 +78,15 @@ public class TrezorDevice implements Closeable, ProtocolCallbacks {
     }
 
     public void initDevice() throws DeviceException {
-        TrezorMessageManagement.Initialize initialize = TrezorMessageManagement.Initialize.newBuilder().build();
-        Message response = protocol.callRaw(initialize);
+        initDevice(null);
+    }
+
+    public void initDevice(byte[] previousSessionId) throws DeviceException {
+        TrezorMessageManagement.Initialize.Builder builder = TrezorMessageManagement.Initialize.newBuilder();
+        if(previousSessionId != null && previousSessionId.length > 0) {
+            builder.setSessionId(ByteString.copyFrom(previousSessionId));
+        }
+        Message response = protocol.callRaw(builder.build());
         if(response instanceof TrezorMessageManagement.Features msgFeatures) {
             this.sessionId = msgFeatures.getSessionId().toByteArray();
             refreshFeatures(msgFeatures);
@@ -404,6 +411,10 @@ public class TrezorDevice implements Closeable, ProtocolCallbacks {
         }
 
         return features.getCapabilitiesList().contains(TrezorMessageManagement.Features.Capability.Capability_PassphraseEntry);
+    }
+
+    public byte[] getSessionId() {
+        return sessionId;
     }
 
     @Override


### PR DESCRIPTION
## Summary

- **Add KeepKey to `needsPassphraseSent` model check** — KeepKey was missing from the condition in `TrezorClient.prepareDevice()` that sets `needsPassphraseSent` based on `passphrase_protection`. This caused wallet applications (Sparrow, Specter) to never prompt for a passphrase when using KeepKey, resulting in an infinite "enable passphrase" loop.

- **Cache and reuse session ID across `TrezorDevice` instances** — Each call to `getPubKeyAtPath`, `signTransaction`, etc. creates a new `TrezorDevice`, which previously triggered a fresh `Initialize` without a session ID. This caused repeated passphrase confirmation prompts on the device during batch operations like keystore discovery (30+ prompts). Now the session ID from the first successful exchange is cached in `TrezorClient` and passed in subsequent `Initialize` messages, allowing the device to resume the session silently.

- **Preserve `needsPassphraseSent` flag during enumerate** — Previously, `prepareDevice()` unconditionally cleared `needsPassphraseSent` after successfully sending an empty passphrase during enumeration. This prevented the UI from ever showing the passphrase prompt. Now the flag is only cleared when the user has actually provided a non-empty passphrase.

## Files Changed

- `TrezorClient.java` — Add `sessionId` field, pass to `initDevice()`, add KeepKey to model check, conditional flag reset
- `TrezorDevice.java` — Add `initDevice(byte[] previousSessionId)` overload, add `getSessionId()` getter

## Testing

Fully tested with a physical KeepKey device:
- [x] Connect KeepKey with passphrase protection enabled
- [x] Sparrow shows "Set Passphrase" button on device connection
- [x] Enter passphrase and fingerprint is retrieved correctly
- [x] Keystore discovery only prompts for passphrase once, not per-account
- [x] Full Sparrow project builds and all Lark tests pass

— KeepKey Development <highlander@keepkey.com>