### PR TITLE
fix: hw wallet naming in SP creation error

### DIFF
--- a/src/main/java/com/sparrowwallet/lark/HardwareClient.java
+++ b/src/main/java/com/sparrowwallet/lark/HardwareClient.java
@@ -29,7 +29,7 @@ public abstract class HardwareClient {
     abstract String displayMultisigAddress(OutputDescriptor outputDescriptor) throws DeviceException;
 
     SilentPaymentScanAddress getSpscanAtPath(String path) throws DeviceException {
-        throw new DeviceException(getModel().toDisplayString() + " does not support receiving silent payments");
+        throw new DeviceException(getHardwareType().getDisplayName() + " does not support receiving silent payments over a direct connection.");
     }
 
     public String getType() {


### PR DESCRIPTION
The base `HardwareClient.getSpscanAtPath()` error used `getModel()`, but this is invoked before device is opened, so always returned its fallback. e.g. a Trezor Safe 3 reported *"Trezor T does not support receiving silent payments".*

<img width="653" height="256" alt="shot" src="https://github.com/user-attachments/assets/52a59361-5660-484b-ac82-54a00d996028" />

In this PR I've switched to `getHardwareType().getDisplayName()` instead, which is a constant per client and available without connecting / unlocking etc. In the case above it returns simply "Trezor". 

Also clarified the wording to note the limitation applies over a direct connection.