### PR TITLE
Add Banshee hardware wallet client

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The following hardware wallets (for all models, unless specified) are supported:
 - Ledger
 - BitBox02
 - Jade
+- Banshee
 - Keepkey
 - OneKey (Classic 1S and Pro)
 

--- a/src/main/java/com/sparrowwallet/lark/BansheeClient.java
+++ b/src/main/java/com/sparrowwallet/lark/BansheeClient.java
@@ -1,0 +1,111 @@
+package com.sparrowwallet.lark;
+
+import com.fazecast.jSerialComm.SerialPort;
+import com.sparrowwallet.drongo.*;
+import com.sparrowwallet.drongo.protocol.ScriptType;
+import com.sparrowwallet.drongo.psbt.PSBT;
+import com.sparrowwallet.drongo.psbt.PSBTParseException;
+import com.sparrowwallet.drongo.wallet.WalletModel;
+
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Lark client for the Banshee hardware wallet (LilyGo T-Display S3).
+ */
+public class BansheeClient extends HardwareClient {
+    public static final List<DeviceId> BANSHEE_DEVICE_IDS = List.of(new DeviceId(0x303a, 0xb05e));
+
+    private final SerialPort serialPort;
+    private final String network;
+    private String masterFingerprint;
+
+    public BansheeClient(SerialPort serialPort) throws DeviceException {
+        if(BANSHEE_DEVICE_IDS.stream().noneMatch(id -> id.matches(serialPort))) {
+            throw new DeviceException("Not a Banshee");
+        }
+        this.serialPort = serialPort;
+        this.network = Network.getCanonical();
+    }
+
+    @Override
+    void initializeMasterFingerprint() throws DeviceException {
+        try(BansheeGate gate = new BansheeGate(serialPort, network)) {
+            this.masterFingerprint = Utils.bytesToHex(ExtendedKey.fromDescriptor(gate.getXpub("m/0h")).getParentFingerprint());
+        }
+    }
+
+    @Override
+    ExtendedKey getPubKeyAtPath(String path) throws DeviceException {
+        try(BansheeGate gate = new BansheeGate(serialPort, network)) {
+            return ExtendedKey.fromDescriptor(gate.getXpub(path));
+        }
+    }
+
+    @Override
+    PSBT signTransaction(PSBT psbt) throws DeviceException {
+        try(BansheeGate gate = new BansheeGate(serialPort, network)) {
+            byte[] psbtBytes = psbt.getForExport().serialize();
+            String b64 = Base64.getEncoder().encodeToString(psbtBytes);
+            String signedB64 = gate.signPsbt(b64);
+            return new PSBT(Base64.getDecoder().decode(signedB64));
+        } catch(PSBTParseException e) {
+            throw new DeviceException("Invalid signed PSBT from Banshee", e);
+        }
+    }
+
+    @Override
+    String signMessage(String message, String path) throws DeviceException {
+        throw new DeviceException("Banshee does not support message signing yet");
+    }
+
+    @Override
+    String displaySinglesigAddress(String path, ScriptType scriptType) throws DeviceException {
+        throw new DeviceException("Banshee does not support address display via host yet");
+    }
+
+    @Override
+    String displayMultisigAddress(OutputDescriptor outputDescriptor) throws DeviceException {
+        throw new DeviceException("Banshee does not support multisig yet");
+    }
+
+    @Override
+    public String getPath() {
+        return serialPort.getSystemPortPath();
+    }
+
+    @Override
+    public HardwareType getHardwareType() {
+        return HardwareType.BANSHEE;
+    }
+
+    @Override
+    public WalletModel getModel() {
+        return WalletModel.BANSHEE;
+    }
+
+    @Override
+    public Boolean needsPinSent() {
+        return false;
+    }
+
+    @Override
+    public Boolean needsPassphraseSent() {
+        return false;
+    }
+
+    @Override
+    public String fingerprint() {
+        return masterFingerprint;
+    }
+
+    @Override
+    public boolean card() {
+        return false;
+    }
+
+    @Override
+    public String[][] warnings() {
+        return new String[0][];
+    }
+}

--- a/src/main/java/com/sparrowwallet/lark/BansheeGate.java
+++ b/src/main/java/com/sparrowwallet/lark/BansheeGate.java
@@ -1,0 +1,171 @@
+package com.sparrowwallet.lark;
+
+import com.fazecast.jSerialComm.SerialPort;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Text line protocol for Banshee firmware (115200 baud USB serial).
+ */
+public class BansheeGate implements AutoCloseable {
+    private static final int BAUD = 115200;
+    private static final int DEFAULT_TIMEOUT_MS = 5000;
+    private static final int SIGN_TIMEOUT_MS = 70000;
+    private static final int MAX_LINE = 65536;
+
+    private final SerialPort serialPort;
+    private final InputStream in;
+    private final OutputStream out;
+    private final String network;
+
+    public BansheeGate(SerialPort serialPort, String network) throws DeviceException {
+        if(BansheeClient.BANSHEE_DEVICE_IDS.stream().noneMatch(id -> id.matches(serialPort))) {
+            throw new DeviceException("Not a Banshee device");
+        }
+        this.serialPort = serialPort;
+        this.network = network;
+        serialPort.setBaudRate(BAUD);
+        serialPort.setComPortTimeouts(SerialPort.TIMEOUT_READ_SEMI_BLOCKING, DEFAULT_TIMEOUT_MS, 0);
+        if(!serialPort.openPort()) {
+            throw new DeviceException("Could not open Banshee serial port");
+        }
+        try {
+            in = serialPort.getInputStream();
+            out = serialPort.getOutputStream();
+            drainBanner();
+            String status = command("WALLET_STATUS");
+            if(status.contains("ready=0")) {
+                throw new DeviceException("Banshee wallet not initialized. Create a wallet in Banshee Studio first.");
+            }
+        } catch(IOException e) {
+            serialPort.closePort();
+            throw new DeviceException("Banshee serial error", e);
+        }
+    }
+
+    private void drainBanner() throws IOException, DeviceException {
+        long deadline = System.currentTimeMillis() + 2000;
+        while(System.currentTimeMillis() < deadline) {
+            String line = readLine(250);
+            if(line.isEmpty()) {
+                continue;
+            }
+            if(line.startsWith("OK READY")) {
+                return;
+            }
+            if(line.startsWith("OK ") || line.startsWith("ERR ")) {
+                return;
+            }
+        }
+    }
+
+    public String command(String cmd) throws DeviceException {
+        try {
+            out.write((cmd + "\n").getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            String resp = readLine(DEFAULT_TIMEOUT_MS);
+            return parseOk(resp);
+        } catch(IOException e) {
+            throw new DeviceException("Banshee command failed: " + cmd, e);
+        }
+    }
+
+    public String signPsbt(String psbtBase64) throws DeviceException {
+        try {
+            out.write(("SIGN_PSBT " + network + " " + psbtBase64 + "\n").getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            String wait = readLine(DEFAULT_TIMEOUT_MS);
+            parseOk(wait);
+            if(!wait.contains("WAIT")) {
+                throw new DeviceException("Unexpected Banshee sign response: " + wait);
+            }
+            String signed = readLine(SIGN_TIMEOUT_MS);
+            if(signed.startsWith("ERR ")) {
+                if(signed.contains("timeout")) {
+                    throw new DeviceException("Signing timed out on Banshee (press BOOT to confirm)");
+                }
+                throw new DeviceException(signed.substring(4));
+            }
+            return parseOkPrefix(signed, "PSBT ");
+        } catch(IOException e) {
+            throw new DeviceException("Banshee sign failed", e);
+        }
+    }
+
+    public String getFingerprint() throws DeviceException {
+        return parseOkPrefix(command("GET_FINGERPRINT"), "FINGERPRINT ");
+    }
+
+    public String getXpub(String path) throws DeviceException {
+        String normalized = path.replace('\'', 'h');
+        return parseOkPrefix(command("GET_XPUB " + network + " " + normalized), "XPUB ");
+    }
+
+    private static String parseOk(String line) throws DeviceException {
+        if(line.startsWith("ERR ")) {
+            throw new DeviceException(line.substring(4));
+        }
+        if(!line.startsWith("OK ")) {
+            throw new DeviceException(line.isEmpty() ? "Banshee timeout" : line);
+        }
+        return line.substring(3);
+    }
+
+    private static String parseOkPrefix(String line, String prefix) throws DeviceException {
+        String rest = parseOk(line.startsWith("OK ") ? line : "OK " + line);
+        if(!rest.startsWith(prefix)) {
+            throw new DeviceException("Unexpected Banshee response: " + line);
+        }
+        return rest.substring(prefix.length()).trim();
+    }
+
+    private String readLine(int timeoutMs) throws IOException {
+        List<Byte> buf = new ArrayList<>();
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while(System.currentTimeMillis() < deadline) {
+            if(in.available() > 0) {
+                int b = in.read();
+                if(b < 0) {
+                    break;
+                }
+                if(b == '\r') {
+                    continue;
+                }
+                if(b == '\n') {
+                    return new String(toBytes(buf), StandardCharsets.UTF_8).trim();
+                }
+                if(buf.size() < MAX_LINE) {
+                    buf.add((byte)b);
+                }
+            } else {
+                try {
+                    Thread.sleep(5);
+                } catch(InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+        return "";
+    }
+
+    private static byte[] toBytes(List<Byte> bytes) {
+        byte[] arr = new byte[bytes.size()];
+        for(int i = 0; i < bytes.size(); i++) {
+            arr[i] = bytes.get(i);
+        }
+        return arr;
+    }
+
+    @Override
+    public void close() {
+        if(serialPort.isOpen()) {
+            serialPort.closePort();
+        }
+    }
+}

--- a/src/main/java/com/sparrowwallet/lark/HardwareType.java
+++ b/src/main/java/com/sparrowwallet/lark/HardwareType.java
@@ -37,6 +37,12 @@ public enum HardwareType {
             return new KeepkeyClient(device, deviceDescriptor);
         }
     },
+    BANSHEE("banshee", Interface.SERIAL) {
+        @Override
+        public HardwareClient createClient(SerialPort serialPort, HttpClientService httpClientService) throws DeviceException {
+            return new BansheeClient(serialPort);
+        }
+    },
     LEDGER("ledger", Interface.HID) {
         @Override
         public HardwareClient createClient(HidDevice hidDevice) throws DeviceException {

--- a/src/main/resources/udev/56-usb-banshee.rules
+++ b/src/main/resources/udev/56-usb-banshee.rules
@@ -1,0 +1,1 @@
+KERNEL=="ttyACM*", SUBSYSTEMS=="usb", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="b05e", MODE="0660", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="banshee%n"

--- a/src/main/resources/udev/README.md
+++ b/src/main/resources/udev/README.md
@@ -8,7 +8,8 @@ These are necessary for the devices to be reachable on linux environments.
  - `51-trezor.rules` (Trezor): https://github.com/trezor/trezor-common/blob/master/udev/51-trezor.rules
  - `51-usb-keepkey.rules` (Keepkey): https://github.com/keepkey/udev-rules/blob/master/51-usb-keepkey.rules
  - `53-hid-bitbox02.rules`, `54-hid-bitbox02.rules` (Bitbox02): https://github.com/BitBoxSwiss/bitbox-wallet-app/blob/master/frontends/qt/resources/deb-afterinstall.sh
- - `55-usb-jade.rules` (Jade) https://github.com/Blockstream/Jade/blob/master/flashing/98-jade-flasher.rules
+ - `55-usb-jade.rules`
+ - `56-usb-banshee.rules` (Banshee): https://github.com/CuseTheJuice/my-banshee-hardware-app (Jade) https://github.com/Blockstream/Jade/blob/master/flashing/98-jade-flasher.rules
 
 # Usage
 


### PR DESCRIPTION
Adds Lark support for **Banshee**, an open-source Bitcoin hardware wallet on LilyGo T-Display S3 (ESP32-S3).

Depends on sparrowwallet/drongo#48 (`WalletModel.BANSHEE`).

- Repository: https://github.com/CuseTheJuice/my-banshee-hardware-app
- USB: Espressif `303a:b05e` (distinct from Jade `303a:4001`)
- Communication: newline-delimited text protocol over USB serial at 115200 baud
- BIP39 seed on device; xpub export and PSBT signing with on-device BOOT confirmation
- Vendor commits to maintaining firmware and this driver

## Included

- `BansheeGate.java` — serial protocol (115200 baud)
- `BansheeClient.java` — enumerate, xpub, PSBT signing
- `HardwareType.BANSHEE` registration (serial, like Jade)
- `56-usb-banshee.rules` + udev README

## Supported in v1

- BIP84 native segwit and legacy P2PKH PSBT inputs
- No Taproot, multisig, message signing, or host-driven address display yet
- Wallet setup is on-device (not via Lark)

## Test plan

- [ ] `lark enumerate` detects device at `303a:b05e`
- [ ] `lark --device-type banshee getxpub "m/84'/0'/0'"`
- [ ] `lark --device-type banshee signtx <psbt>` with BOOT confirmation on device

Companion HWI PR: bitcoin-core/HWI#848

Made with [Cursor](https://cursor.com)